### PR TITLE
Fix NextAuth session type import

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -27,7 +27,7 @@ export async function getBooks({
   cursor?: string | null;
 }) {
   const session = await getUserSession();
-  const where: any = {
+  const where: Record<string, unknown> = {
     userId: session.user.id,
   };
   if (query) {
@@ -76,7 +76,7 @@ export async function addBook(formData: FormData) {
     lentAt,
     tags
   } = validatedFields.data;
-  let cover = validatedFields.data.cover;
+  const cover = validatedFields.data.cover;
 
   let coverPath: string | null = null;
 
@@ -185,7 +185,7 @@ export async function updateBook(id: string, formData: FormData) {
     lentAt,
     tags
   } = validatedFields.data;
-  let cover = validatedFields.data.cover;
+  const cover = validatedFields.data.cover;
 
   let coverPath: string | null = null;
 
@@ -231,7 +231,7 @@ export async function updateBook(id: string, formData: FormData) {
     }
   }
 
-  const dataToUpdate: any = {
+  const dataToUpdate: Record<string, unknown> = {
     title,
     author: author || "Unknown Author",
     isbn: isbn || null,
@@ -293,7 +293,7 @@ export async function searchBookByISBN(isbn: string): Promise<Partial<BookFormVa
       const book = data[bookKey];
       return {
         title: book.title,
-        author: book.authors ? book.authors.map((a: { name: any; }) => a.name).join(", ") : "Unknown Author",
+        author: book.authors ? book.authors.map((a: { name: string }) => a.name).join(", ") : "Unknown Author",
         description: typeof book.notes === 'string' ? book.notes : '',
         cover: book.cover?.large,
         publishedAt: book.publish_date,

--- a/src/components/books/EditBook.tsx
+++ b/src/components/books/EditBook.tsx
@@ -110,7 +110,7 @@ export function EditBook({ book, children }: EditBookProps) {
         <DialogHeader>
           <DialogTitle>Edit Book</DialogTitle>
           <DialogDescription>
-            Make changes to your book here. Click save when you're done.
+            Make changes to your book here. Click save when you&apos;re done.
           </DialogDescription>
         </DialogHeader>
         <form onSubmit={onSubmit} className="space-y-4">

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -17,7 +17,7 @@ export const authOptions: NextAuthOptions = {
     strategy: "jwt",
   },
   callbacks: {
-    async signIn({ user, account, profile }) {
+    async signIn({ user }) {
       // Verificar si el usuario ya existe
       const existingUser = await prisma.user.findUnique({
         where: { email: user.email! },

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,4 +1,5 @@
 import 'next-auth';
+import type { DefaultSession } from 'next-auth';
 
 declare module 'next-auth' {
   interface Session {


### PR DESCRIPTION
## Summary
- add missing `DefaultSession` import for NextAuth session types
- escape apostrophe in edit dialog description
- remove unused NextAuth callback params
- replace `any` types in book actions
- use const for `cover`
- add trailing newlines

## Testing
- `npm install`
- `npm run lint` *(fails: unused variables and other issues remain)*
- `npm run build` *(fails: failed to fetch Prisma engine checksum due to 403)*

------
https://chatgpt.com/codex/tasks/task_e_687cecfe0b248320948969a93e869003